### PR TITLE
Png tweaks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,23 +5,28 @@ version = "0.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 libpng_jll = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 
 [compat]
-CEnum = "0.2"
-FileIO = "1.2"
-FixedPointNumbers = "0.7"
-ImageCore = "0.8"
-julia = "1.3"
+CEnum = "^0.2"
+ColorTypes = "^0.9"
+FileIO = "^1.2"
+FixedPointNumbers = "^0.7"
+ImageCore = "^0.8"
+julia = "^1.3"
 libpng_jll = "1.6.37"
 
 [extras]
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Logging", "Random", "Test"]
+test = ["Glob", "ImageMagick", "Logging", "Random", "Test", "TestImages"]

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,194 +1,292 @@
+"""
+    load(f::File{DataFormat{:PNG}})
 
-function map_color(color_type, bit_depth)
-    if color_type == PNG_COLOR_TYPE_GRAY
-        colors_type = Gray{bit_depth}
-    elseif color_type == PNG_COLOR_TYPE_PALETTE
-        colors_type = RGB{bit_depth}
-    elseif color_type == PNG_COLOR_TYPE_RGB
-        colors_type = RGB{bit_depth}
-    elseif color_type == PNG_COLOR_TYPE_RGB_ALPHA
-        colors_type = RGBA{bit_depth}
-    elseif color_type == PNG_COLOR_TYPE_GRAY_ALPHA
-        colors_type = GrayA{bit_depth}
-    else
-        error("Unknown color type: $color_type")
-    end
-    return colors_type
-end
+Read a `.png` image from file `f`.
+Returns a matrix.
 
-function load(f::File{DataFormat{:PNG}}, transforms::Int = 0)
+The result will be an 8 bit (N0f8) image if the source bit depth is <= 8 bits, 16 bit (N0f16)
+otherwise. The number of channels of the source determines the color type of the output:
+    1 channel  -> Gray
+    2 channels -> GrayA
+    3 channels -> RGB
+    4 channels -> RGBA
+"""
+function load(f::File{DataFormat{:PNG}})
     fp = open_png(f.filename)
-
     png_ptr = create_read_struct()
     info_ptr = create_info_struct(png_ptr)
     png_init_io(png_ptr, fp)
     png_set_sig_bytes(png_ptr, PNG_BYTES_TO_CHECK)
-
-    png_read_png(png_ptr, info_ptr, transforms, C_NULL)
+    png_read_info(png_ptr, info_ptr)
 
     width = png_get_image_width(png_ptr, info_ptr)
     height = png_get_image_height(png_ptr, info_ptr)
     color_type = png_get_color_type(png_ptr, info_ptr)
     bit_depth = png_get_bit_depth(png_ptr, info_ptr)
     num_channels = png_get_channels(png_ptr, info_ptr)
+    interlace_type = png_get_interlace_type(png_ptr, info_ptr)
+    buffer_eltype = _buffer_color_type(color_type, bit_depth)
+
+    @debug(
+        "Read PNG info:",
+        f.filename,
+        height,
+        width,
+        color_type,
+        bit_depth,
+        num_channels,
+        interlace_type,
+        buffer_eltype
+    )
 
     if (color_type == PNG_COLOR_TYPE_PALETTE)
-        error("The color type PNG_COLOR_TYPE_PALETTE is not currently supported.")
+        png_set_palette_to_rgb(png_ptr)
     end
 
-    @debug """Read image info:
-            width=$width,
-            height=$height,
-            color_type=$color_type,
-            bit_depth=$bit_depth,
-            num_channels=$num_channels"""
-
-    even_depth = ((bit_depth + 1) >> 1) << 1
-    if bit_depth <= 8
-        T = Normed{UInt8, 8}
-    elseif bit_depth <= 16
-        T = Normed{UInt16, even_depth}
-    else
-        # TODO UInt32?
-        error("Unknown bit_depth: $bit_depth")
+    if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
+        png_set_expand_gray_1_2_4_to_8(png_ptr)
+        png_set_packing(png_ptr)
+        bit_depth = UInt8(8)
     end
 
-    colors_type = map_color(color_type, T)
-    buf = Array{colors_type}(undef, height, width)
-    get_image_pixels!(rawview(channelview(buf)), png_ptr, info_ptr)
+    if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS) != 0)
+        png_set_tRNS_to_alpha(png_ptr)
+    end
+    isodd(num_channels) && png_set_strip_alpha(png_ptr)
+
+    bit_depth == 16 && png_set_swap(png_ptr)
+    png_set_interlace_handling(png_ptr)
+    png_read_update_info(png_ptr, info_ptr)
+    # We transpose to work around libpng expecting row-major arrays
+    buffer = Array{buffer_eltype}(undef, width, height)
+
+    png_read_image(png_ptr, map(pointer, eachcol(buffer)))
+    png_read_end(png_ptr, info_ptr)
     png_destroy_read_struct(Ref{Ptr{Cvoid}}(png_ptr), Ref{Ptr{Cvoid}}(info_ptr), C_NULL)
     close_png(fp)
-    return buf
+    return transpose(buffer)
 end
 
-function get_image_pixels!(buf::AbstractArray{T, 2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where T<:Unsigned
-    height, width = size(buf)
-    #rows = png_get_rows(png_ptr, info_ptr) #Clang-wrapped version is fixed to UInt8 output!
-    rows = ccall((:png_get_rows, libpng), Ptr{Ptr{T}}, (Ptr{Cvoid}, Ptr{Cvoid}), png_ptr, info_ptr)
-    for i = 1:height
-        row = unsafe_load(rows, i)
-        for j = 1:width
-            buf[i, j] = unsafe_load(row, j)
-        end
+function _buffer_color_type(color_type, bit_depth)
+    if color_type == PNG_COLOR_TYPE_GRAY
+        colors_type = Gray{bit_depth > 8 ? Normed{UInt16,bit_depth} : Normed{UInt8,bit_depth}}
+    elseif color_type == PNG_COLOR_TYPE_PALETTE
+        colors_type = RGB{bit_depth == 16 ? N0f16 : N0f8}
+    elseif color_type == PNG_COLOR_TYPE_RGB
+        colors_type = RGB{bit_depth == 16 ? N0f16 : N0f8}
+    elseif color_type == PNG_COLOR_TYPE_RGB_ALPHA
+        colors_type = RGBA{bit_depth == 16 ? N0f16 : N0f8}
+    elseif color_type == PNG_COLOR_TYPE_GRAY_ALPHA
+        colors_type = GrayA{bit_depth > 8 ? Normed{UInt16,bit_depth} : Normed{UInt8,bit_depth}}
+    else
+        throw(error("Unknown color type: $color_type"))
     end
-    buf
+    return colors_type
 end
 
-function get_image_pixels!(buf::AbstractArray{T, 3}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where T<:Unsigned
-    num_channels, height, width = size(buf)
-    #rows = png_get_rows(png_ptr, info_ptr) #Clang-wrapped version is fixed to UInt8 output!
-    rows = ccall((:png_get_rows, libpng), Ptr{Ptr{T}}, (Ptr{Cvoid}, Ptr{Cvoid}), png_ptr, info_ptr)
-    for i = 1:height
-        row = unsafe_load(rows, i)
-        for j = 1:width
-            for c = 1:num_channels
-                buf[c, i, j] = unsafe_load(row, num_channels * (j - 1) + c)
-            end
-        end
-    end
-    buf
-end
 
-function get_image_pixels!(buf::AbstractArray{T, N}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T, N}
-    error("Image array has invalid dimension $N")
-end
+### Write ##########################################################################################
+"""
+    save(f::File{DataFormat{:PNG}}, image::AbstractArray
+        [, compression_level::Integer=0, compression_strategy::Integer=3, filters::Integer=4,])
 
-to_raw(A::AbstractArray{C}) where C<:Colorant  = to_raw(channelview(A))
-to_raw(A::AbstractArray{T}) where T<:Normed    = rawview(A)
-to_raw(A::AbstractArray{T}) where T<:Real      = to_raw(convert(Array{N0f8}, A))
-to_raw(A::ColorView) = channelview(A)
+Writes `image` as a png to file `f`.
 
-get_bit_depth(img::AbstractArray{C}) where C<:Colorant = _get_bit_depth(eltype(C))
-get_bit_depth(img::AbstractArray{T}) where T<:Normed = _get_bit_depth(T)
-_get_bit_depth(::Type{Normed{T, N}}) where {T, N} = N
-_get_bit_depth(img::Type{T}) where T<:AbstractFloat = 8
-_get_bit_depth(img::Type{Bool}) = 8
+## Arguments
+`compression_level`: 0 (Z_NO_COMPRESSION), 1 (Z_BEST_SPEED), ..., 9 (Z_BEST_COMPRESSION)
+`compression_strategy`: 0 (Z_DEFAULT_STRATEGY), 1 (Z_FILTERED), 2 (Z_HUFFMAN_ONLY), 3 (Z_RLE), 4 (Z_FIXED)
+`filters`: 0 (None), 1 (Sub), 2 (Up), 3 (Average), 4 (Paeth).
 
-get_color_type(::Type{Gray{T}}) where T   = PNG_COLOR_TYPE_GRAY
-get_color_type(::Type{GrayA{T}}) where T  = PNG_COLOR_TYPE_GRAY_ALPHA
-get_color_type(::Type{RGB{T}}) where T    = PNG_COLOR_TYPE_RGB
-get_color_type(::Type{RGBA{T}}) where T   = PNG_COLOR_TYPE_RGBA
-get_color_type(::Type{T}) where T<:Normed = PNG_COLOR_TYPE_RGB
-
-map_image(c::Gray{T}) where T = convert(Gray{N0f8}, c)
-map_image(c::Gray{T}) where T<:Normed = c
-map_image(c::GrayA{T}) where T = convert(GrayA{N0f8}, c)
-map_image(c::GrayA{T}) where T<:Normed = c
-map_image(c::RGB{T}) where T = convert(RGB{N0f8}, c)
-map_image(c::RGB{T}) where T<:Normed = c
-map_image(c::RGBA{T}) where T = convert(RGBA{N0f8}, c)
-map_image(c::RGBA{T}) where T<:Normed = c
-
-map_image(x::Bool) = convert(Gray{N0f8}, x)
-map_image(x::AbstractFloat) = convert(N0f8, x)
-map_image(x::Normed) = x
-
-get_image_size(buffer::AbstractArray{T,2}) where T = size(buffer)
-get_image_size(buffer::AbstractArray{T,N}) where {T, N} = error("Number of dimensions in image of $ndims not supported.")
-function get_image_size(buffer::AbstractArray{T,3}) where T
-    n_channels, height, width = size(buffer)
-    height, width
-end
-
-function save(f::File{DataFormat{:PNG}}, image::AbstractArray{T}) where T
+The saved image will have 16 bits of depth if the `image` has eltype that is based on `UInt16`,
+8 bits otherwise.
+The number of channels and element type of the `image` determines the color type of the
+output:
+    0/1 channel Float / Integer / Normed or Gray eltype        -> PNG_COLOR_TYPE_GRAY
+    2 channels Float  / Integer / Normed or GrayA eltype       -> PNG_COLOR_TYPE_GRAY_ALPHA
+    3 channels Float  / Integer / Normed or RGB / BGR eltype   -> PNG_COLOR_TYPE_RGB
+    4 channels Float  / Integer / Normed or ARGB / ABGR eltype -> PNG_COLOR_TYPE_RGB_ALPHA
+"""
+function save(
+        f::File{DataFormat{:PNG}},
+        image::S,
+        compression_level::Integer=Z_NO_COMPRESSION,
+        compression_strategy::Integer=Z_RLE,
+        filters::Integer=PNG_FILTER_PAETH
+    ) where {
+        T,
+        S<:Union{AbstractMatrix,AbstractArray{T,3}}
+    }
+    @assert Z_DEFAULT_STRATEGY <= compression_strategy <= Z_FIXED
+    @assert Z_NO_COMPRESSION <= compression_level <= Z_BEST_COMPRESSION
+    @assert 2 <= ndims(image) <= 3
+    @assert size(image, 3) <= 4
 
     fp = ccall(:fopen, Ptr{Cvoid}, (Cstring, Cstring), f.filename, "wb")
-    fp == C_NULL && error("Could not open $(filename) for writing")
+    fp == C_NULL && error("Could not open $(f.filename) for writing")
 
     png_ptr = create_write_struct(png_error_fn, png_warn_fn)
     info_ptr = create_info_struct(png_ptr)
     png_init_io(png_ptr, fp)
+    png_set_filter(png_ptr, PNG_FILTER_TYPE_BASE, UInt32(filters))
+    png_set_compression_level(png_ptr, compression_level)
+    png_set_compression_strategy(png_ptr, compression_strategy)
 
-    image = map(map_image, image)
-    buffer = to_raw(image)
+    height, width = size(image)[1:2]
+    bit_depth = _get_bit_depth(image)
+    color_type = _get_color_type(image)
+    interlace = PNG_INTERLACE_NONE
+    compression_type = PNG_COMPRESSION_TYPE_BASE
+    filter_type = PNG_FILTER_TYPE_BASE
 
-    height, width = get_image_size(buffer)
-    bit_depth = get_bit_depth(image)
+    elt = eltype(image)
+    if (elt <: BGR || elt <: BGRA || elt <: ABGR)
+       png_set_bgr(png_ptr)
+    end
 
-    color_type = get_color_type(eltype(image))
-    interlace = 0        # Set to always off
-    compression_type = 0 # Set to always off
-    filter_type = 0      # Set to always off
+    if (elt <: ABGR || elt <: ARGB)
+        png_set_swap_alpha(png_ptr)
+    end
 
-    @debug """Write image info:
-            width=$width,
-            height=$height,
-            bit_depth=$bit_depth,
-            color_type=$color_type,
-            interlace=$interlace,
-            compression_type=$compression_type,
-            filter_type=$filter_type"""
+    if color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8
+        png_set_packing(png_ptr)
+        bit_depth = 8  # TODO: support 1, 2, 4 bit-depth gray images
+    end
 
-    png_set_IHDR(png_ptr, info_ptr, width, height, bit_depth, color_type, interlace, compression_type, filter_type)
+    @debug(
+        "Write PNG info:",
+        f.filename,
+        height,
+        width,
+        bit_depth,
+        color_type,
+        interlace,
+        compression_type,
+        filter_type,
+        filters,
+        compression_level,
+        compression_strategy,
+        typeof(image)
+    )
+
+    # TODO: on error this throws an abort signal because we currently don't handle `longjmp`
+    png_set_IHDR(
+        png_ptr,
+        info_ptr,
+        width,
+        height,
+        bit_depth,
+        color_type,
+        interlace,
+        compression_type,
+        filter_type,
+    )
     png_write_info(png_ptr, info_ptr)
-    #png_set_swap(png_ptr)
-    write_rows(buffer, png_ptr, info_ptr)
+    bit_depth == 16 && png_set_swap(png_ptr) # Handles endianness for 16 bit
+
+    # We transpose to work around libpng expecting row-major arrays
+    _write_image(transpose(_prepare_buffer(image)), png_ptr, info_ptr)
+
     png_destroy_write_struct(Ref(png_ptr), Ref(info_ptr))
     close_png(fp)
-
-    return nothing
 end
 
-# 2 dim matrix
-function write_rows(buf::AbstractArray{T, 2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where T
-    height, width = get_image_size(buf)
-    for row = 1:height
-        row_buf = buf[row, :]
-        png_write_row(png_ptr, row_buf)
-    end
+function _write_image(buf::AbstractArray{T,2}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T}
+    ccall(
+        (:png_write_image, libpng),
+        Cvoid,
+        (Ptr{Cvoid}, Ptr{Ptr{T}}),
+        png_ptr,
+        map(pointer, eachcol(buf)),
+    )
     png_write_end(png_ptr, info_ptr)
 end
 
-# 3-dim matrix
-function write_rows(buf::AbstractArray{T, 3}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where T
-    height, width = get_image_size(buf)
-    for row = 1:height
-        row_buf = buf[:, row, :]
-        png_write_row(png_ptr, row_buf)
+_prepare_buffer(x::BitArray) where {T<:Colorant{<:Normed}} = _prepare_buffer(collect(x))
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Colorant{<:Normed}} = x
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:UInt8} = reinterpret(Gray{N0f8}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:UInt16} = reinterpret(Gray{N0f16}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Normed} = reinterpret(Gray{T}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Gray{<:AbstractFloat}} =
+    convert(Array{Gray{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:GrayA{<:AbstractFloat}} =
+    convert(Array{GrayA{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:RGB{<:AbstractFloat}} =
+    convert(Array{RGB{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:RGBA{<:AbstractFloat}} =
+    convert(Array{RGBA{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:BGR{<:AbstractFloat}} =
+    convert(Array{RGB{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:BGRA{<:AbstractFloat}} =
+    convert(Array{RGBA{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:ARGB{<:AbstractFloat}} =
+    convert(Array{RGBA{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:ABGR{<:AbstractFloat}} =
+    convert(Array{RGBA{N0f8}}, x)
+_prepare_buffer(x::AbstractMatrix{<:T}) where {T<:Union{AbstractFloat,Bool}} =
+    reinterpret(Gray{N0f8}, convert(Array{N0f8}, x))
+_prepare_buffer(x::AbstractArray{T,3}) where {T<:Union{AbstractFloat,Bool}} =
+    __prepare_buffer(convert(Array{N0f8}, x))
+_prepare_buffer(x::AbstractArray{T,3}) where {T<:Union{UInt8,Int8}} =
+    __prepare_buffer(reinterpret(N0f8, x))
+_prepare_buffer(x::AbstractArray{T,3}) where {T<:Union{UInt16,Int16}} =
+    __prepare_buffer(reinterpret(N0f16, x))
+_prepare_buffer(x::AbstractArray{T,3}) where {T<:Normed} = __prepare_buffer(x)
+
+function __prepare_buffer(x::AbstractArray{T,3}) where {T}
+    nchannels = size(x, 3)
+    if nchannels == 1
+        ifelse(ndims(x) == 3, _prepare_buffer(dropdims(x, dims=3)), x)
+    elseif nchannels == 2
+        convert(Array{GrayA}, colorview(GrayA, view(x, :, :, 1), view(x, :, :, 2)))
+    elseif nchannels == 3
+        convert(Array{RGB}, colorview(RGB, view(x, :, :, 1), view(x, :, :, 2), view(x, :, :, 3)))
+    elseif nchannels == 4
+        convert(
+            Array{RGBA},
+            colorview(RGBA, view(x, :, :, 1), view(x, :, :, 2), view(x, :, :, 3), view(x, :, :, 4)),
+        )
+    else
+        error("Unsupported number of channels $(nchannels) in input. Only <= 4 is expected.")
     end
-    png_write_end(png_ptr, info_ptr)
 end
 
-function write_rows(buf::AbstractArray{T, N}, png_ptr::Ptr{Cvoid}, info_ptr::Ptr{Cvoid}) where {T, N}
-    error("Image has invalid dimension $N")
+_get_bit_depth(img::BitArray) = 8  # TODO: write 1 bit-depth images
+_get_bit_depth(img::AbstractArray{C}) where {C<:Colorant} = __get_bit_depth(eltype(C))
+_get_bit_depth(img::AbstractArray{T}) where {T<:Normed} = __get_bit_depth(T)
+# __get_bit_depth(::Type{Normed{T,1}}) where T = 1  # TODO: write 1 bit-depth images
+# __get_bit_depth(::Type{Normed{T,2}}) where T = 2  # TODO: write 2 bit-depth images
+# __get_bit_depth(::Type{Normed{T,4}}) where T = 4  # TODO: write 4 bit-depth images
+__get_bit_depth(::Type{Normed{T,8}}) where T = 8
+__get_bit_depth(::Type{Normed{T,16}}) where T = 16
+__get_bit_depth(::Type{Normed{T,N}}) where {T,N} = ifelse(N <= 8, 8, 16)
+__get_bit_depth(::Type{<:AbstractFloat}) = 8
+_get_bit_depth(img::AbstractArray{T}) where {T<:AbstractFloat} = 8
+_get_bit_depth(img::AbstractArray{<:Bool}) = 8  # TODO: write 1 bit-depth images
+_get_bit_depth(img::AbstractArray{<:UInt8}) = 8
+_get_bit_depth(img::AbstractArray{<:UInt16}) = 16
+
+_get_color_type(x::AbstractArray{<:Gray{T}}) where {T} = PNG_COLOR_TYPE_GRAY
+_get_color_type(x::AbstractArray{<:GrayA{T}}) where {T} = PNG_COLOR_TYPE_GRAY_ALPHA
+_get_color_type(x::AbstractArray{<:RGB{T}}) where {T} = PNG_COLOR_TYPE_RGB
+_get_color_type(x::AbstractArray{<:RGBA{T}}) where {T} = PNG_COLOR_TYPE_RGBA
+_get_color_type(x::AbstractArray{<:BGR{T}}) where {T} = PNG_COLOR_TYPE_RGB
+_get_color_type(x::AbstractArray{<:BGRA{T}}) where {T} = PNG_COLOR_TYPE_RGBA
+_get_color_type(x::AbstractArray{<:ARGB{T}}) where {T} = PNG_COLOR_TYPE_RGBA
+_get_color_type(x::AbstractArray{<:ABGR{T}}) where {T} = PNG_COLOR_TYPE_RGBA
+function _get_color_type(
+        x::AbstractArray{T, N}
+    ) where {
+        T<:Union{Normed,Unsigned,Bool,AbstractFloat},
+        N
+    }
+    if N == 2
+        return PNG_COLOR_TYPE_GRAY
+    elseif N == 3
+        d = size(x, 3)
+        d == 1 && (return PNG_COLOR_TYPE_GRAY)
+        d == 2 && (return PNG_COLOR_TYPE_GRAY_ALPHA)
+        d == 3 && (return PNG_COLOR_TYPE_RGB)
+        d == 4 && (return PNG_COLOR_TYPE_RGBA)
+    end
+    error("Number of dimensions $(N) in image not supported (only 2D or 3D Arrays are expected).")
 end

--- a/src/wraphelpers.jl
+++ b/src/wraphelpers.jl
@@ -1,7 +1,19 @@
-png_error_handler(::Ptr{Cvoid}, msg::Cstring) = error("Png error: $msg")
-png_warn_handler(::Ptr{Cvoid}, msg::Cstring) = warn("Png warn: $msg")
+png_error_handler(::Ptr{Cvoid}, msg::Cstring) = error("Png error: $(unsafe_string(msg))")
+png_warn_handler(::Ptr{Cvoid}, msg::Cstring) = @warn("Png warn: $(unsafe_string(msg))")
 const png_error_fn = @cfunction(png_error_handler, Cvoid, (Ptr{Cvoid}, Cstring))
 const png_warn_fn = @cfunction(png_warn_handler, Cvoid, (Ptr{Cvoid}, Cstring))
+
+# Compression strategy
+const Z_DEFAULT_STRATEGY = 0
+const Z_FILTERED = 1
+const Z_HUFFMAN_ONLY = 2
+const Z_RLE = 3
+const Z_FIXED = 4
+
+# Compression level
+const Z_NO_COMPRESSION = 0
+const Z_BEST_SPEED = 1
+const Z_BEST_COMPRESSION = 9
 
 # Returns the libpng version string
 function get_libpng_version()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,95 +1,193 @@
-using PNG
-using FileIO: DataFormat, @format_str, Stream, File, filename, stream
-using Test
+using ColorTypes
 using FixedPointNumbers
 using ImageCore
 using Logging
-using Random
+using Test
+using TestImages
+using Glob
+using PNG: _prepare_buffer, load, save
+using FileIO: DataFormat, File
 
-#logger = ConsoleLogger(stdout, Logging.Debug)
 logger = ConsoleLogger(stdout, Logging.Info)
 global_logger(logger)
 
-tmpdir = joinpath(@__DIR__,"temp")
-@testset "PNG" begin
-    isdir(tmpdir) && rm(tmpdir, recursive = true)
-    mkdir(tmpdir)
+PNG_TEST_PATH = joinpath(@__DIR__, "temp")
+isdir(PNG_TEST_PATH) && rm(PNG_TEST_PATH, recursive = true)
+mkdir(PNG_TEST_PATH)
 
-    img = rand(Bool, 5, 5, 5, 5)
-    filepath = joinpath(tmpdir, "5x5x5x5.png")
-    @test_throws ErrorException PNG.save(File{DataFormat{:PNG}}(filepath), img)
+PNG_SUITE_DIR = "PngSuite"
+PNG_SUITE_PATH = joinpath(PNG_TEST_PATH, PNG_SUITE_DIR)
+PNG_SUITE_FILE = joinpath(PNG_TEST_PATH, "PngSuite.tgz")
 
-    @testset "Binary Image" begin
-        a = rand(Bool, 11, 10)
-        filepath = joinpath(tmpdir, "binary1.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), a)
-        b1 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test b1 == convert(Array{Gray{N0f8}}, a)
-
-        a = bitrand(5,5)
-        filepath = joinpath(tmpdir, "binary2.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), a)
-        b2 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test b2 == convert(Array{Gray{N0f8}}, a)
-
-        a = colorview(Gray, a)
-        filepath = joinpath(tmpdir, "binary3.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), a)
-        b3 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test b3 == convert(Array{Gray{N0f8}}, a)
+try
+    if !isdir(PNG_SUITE_PATH)
+        mkdir(PNG_SUITE_PATH)
+        download("http://www.schaik.com/pngsuite/PngSuite-2017jul19.tgz", PNG_SUITE_FILE)
+        run(`tar xzf $(PNG_SUITE_FILE) -C $(PNG_SUITE_PATH)`)
+        rm(PNG_SUITE_FILE)
     end
-
-    @testset "Gray image" begin
-        gray = vcat(fill(Gray(1.0), 10, 10), fill(Gray(0.5), 10, 10), fill(Gray(0.0), 10, 10))
-        filepath = joinpath(tmpdir, "gray1.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), gray)
-        g1 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test g1 == convert(Array{Gray{N0f8}}, gray)
-
-        gray = rand(Gray{N0f8}, 5, 5)
-        filepath = joinpath(tmpdir, "gray2.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), gray)
-        g2 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test g2 == gray
-    end
-
-    @testset "Color - RGB" begin
-        #rgb8 = rand(RGB{N0f8}, 10, 5)
-        rgb8 = reshape(range(RGB{N0f8}(1,0,0),RGB{N0f8}(0,1,1), length=10*5), 10, 5)
-        filepath = joinpath(tmpdir, "rgb_n0f8.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), rgb8)
-        r1 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test r1 == rgb8
-
-        #rgb16 = rand(RGB{N0f16}, 10, 5)
-        rgb16 = reshape(range(RGB{N0f16}(1,0,0),RGB{N0f16}(0,1,1), length=10*5), 10, 5)
-        filepath = joinpath(tmpdir, "rgb_n0f16.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), rgb16)
-        r2 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        PNG.save(File{DataFormat{:PNG}}(joinpath(tmpdir, "rgb_n0f16_resave.png")), r2)
-        @test r2 == rgb16
-    end
-
-    @testset "Alpha" begin
-        # RGBA
-        r = RGBA(1.0,0.0,0.0, 0.2)
-        g = RGBA(0.0,1.0,0.0, 0.8)
-        b = RGBA(0.0,0.0,1.0, 1.0)
-        rgba1 = vcat(fill(r, 50,100), fill(g, 50,100), fill(b, 50,100))
-        filepath = joinpath(tmpdir, "rgba1.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), rgba1)
-        r1 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test r1 == rgba1
-
-        # GrayA
-        r = GrayA(1.0, 0.25)
-        g = GrayA(0.5, 0.5)
-        b = GrayA(0.0, 0.75)
-        graya = vcat(fill(r, 50,100), fill(g, 50,100), fill(b, 50,100))
-        filepath = joinpath(tmpdir, "graya1.png")
-        PNG.save(File{DataFormat{:PNG}}(filepath), graya)
-        g1 = PNG.load(File{DataFormat{:PNG}}(filepath))
-        @test g1 == convert(Array{GrayA{N0f8}}, graya)
-    end
-    # TODO implement palette
+catch
+    rm(PNG_SUITE_PATH, recursive=true)
 end
+
+
+_convert(C, T, xs::AbstractArray) =
+    collect(colorview(C, map(i -> collect(reinterpret(T, collect(xs)[:, :, i])), 1:size(xs, 3))...))
+_convert(C, T, xs::AbstractMatrix) = collect(colorview(C, collect(reinterpret(T, collect(xs)))))
+
+
+real_imgs = [
+    splitext(img_name)[1] => testimage(img_name)
+    for img_name
+    in TestImages.remotefiles
+    if endswith(img_name, ".png")
+]
+
+synth_imgs = [
+    "Float64_0" => rand(127, 257),
+    "Float64_1" => rand(127, 257, 1),
+    "Float64_2" => rand(127, 257, 2),
+    "Float64_3" => rand(127, 257, 3),
+    "Float64_4" => rand(127, 257, 4),
+    "Bool_0" => rand(Bool, 127, 257),
+    "Bool_1" => rand(Bool, 127, 257, 1),
+    "Bool_2" => rand(Bool, 127, 257, 2),
+    "Bool_3" => rand(Bool, 127, 257, 3),
+    "Bool_4" => rand(Bool, 127, 257, 4),
+    "UInt8_0" => rand(UInt8, 127, 257),
+    "UInt8_1" => rand(UInt8, 127, 257, 1),
+    "UInt8_2" => rand(UInt8, 127, 257, 2),
+    "UInt8_3" => rand(UInt8, 127, 257, 3),
+    "UInt8_4" => rand(UInt8, 127, 257, 4),
+    "UInt16_0" => rand(UInt16, 127, 257),
+    "UInt16_1" => rand(UInt16, 127, 257, 1),
+    "UInt16_2" => rand(UInt16, 127, 257, 2),
+    "UInt16_3" => rand(UInt16, 127, 257, 3),
+    "UInt16_4" => rand(UInt16, 127, 257, 4),
+    "N0f8_0" => rand(N0f8, 127, 257),
+    "N0f8_1" => rand(N0f8, 127, 257, 1),
+    "N0f8_2" => rand(N0f8, 127, 257, 2),
+    "N0f8_3" => rand(N0f8, 127, 257, 3),
+    "N0f8_4" => rand(N0f8, 127, 257, 4),
+    "N0f16_0" => rand(N0f16, 127, 257),
+    "N0f16_1" => rand(N0f16, 127, 257, 1),
+    "N0f16_2" => rand(N0f16, 127, 257, 2),
+    "N0f16_3" => rand(N0f16, 127, 257, 3),
+    "N0f16_4" => rand(N0f16, 127, 257, 4),
+    "Gray" => rand(Gray, 127, 257),
+    "GrayA" => rand(GrayA, 127, 257),
+    "RGB" => rand(RGB, 127, 257),
+    "RGBA" => rand(RGBA, 127, 257),
+    "GrayN0f8" => rand(Gray{N0f8}, 127, 257),
+    "GrayAN0f8" => rand(GrayA{N0f8}, 127, 257),
+    "RGBN0f8" => rand(RGB{N0f8}, 127, 257),
+    "RGBAN0f8" => rand(RGBA{N0f8}, 127, 257),
+    "GrayN0f16" => rand(Gray{N0f16}, 127, 257),
+    "GrayAN0f16" => rand(GrayA{N0f16}, 127, 257),
+    "RGBN0f16" => rand(RGB{N0f16}, 127, 257),
+    "RGBAN0f16" => rand(RGBA{N0f16}, 127, 257),
+]
+
+invalid_imgs = [
+    ("too_few_dimensions", MethodError, rand(127)),
+    ("too_many_channels", AssertionError, rand(127, 257, 5)),
+    ("too_many_dimensions", MethodError, rand(127, 257, 3, 1)),
+]
+
+edge_case_imgs = [
+    ("BitArray_0", x->_convert(Gray, N7f1, x), randn(127, 257) .> 0),
+    ("BitArray_1", x->_convert(Gray, N7f1, x), randn(127, 257, 1) .> 0),
+    ("BitArray_2", x->_convert(GrayA, N7f1, x), randn(127, 257, 2) .> 0),
+    ("BitArray_3", x->_convert(RGB, N7f1, x), randn(127, 257, 3) .> 0),
+    ("BitArray_4", x->_convert(RGBA, N7f1, x), randn(127, 257, 4) .> 0),
+    ("N4f12_0", x->_convert(Gray, N0f16, x), rand(N4f12,127, 257)),
+    ("N4f12_1", x->_convert(Gray, N0f16, x), rand(N4f12,127, 257, 1)),
+    ("N4f12_2", x->_convert(GrayA, N0f16, x), rand(N4f12,127, 257, 2)),
+    ("N4f12_3", x->_convert(RGB, N0f16, x), rand(N4f12,127, 257, 3)),
+    ("N4f12_4", x->_convert(RGBA, N0f16, x), rand(N4f12,127, 257, 4)),
+    ("BGRN0f8", identity, rand(BGR{N0f8}, 127, 257)),
+    ("BGRAN0f8", identity, rand(BGRA{N0f8}, 127, 257)),
+    ("BGRN0f16", identity, rand(BGR{N0f16}, 127, 257)),
+    ("BGRAN0f16", identity, rand(BGRA{N0f16}, 127, 257)),
+    ("ABGRN0f8", identity, rand(ABGR{N0f8}, 127, 257)),
+    ("ABGRN0f16", identity, rand(ABGR{N0f16}, 127, 257)),
+    ("ARGBN0f8", identity, rand(ARGB{N0f8}, 127, 257)),
+    ("ARGBN0f16", identity, rand(ARGB{N0f16}, 127, 257)),
+]
+
+@testset "libpng" begin
+    for (case, image) in vcat(synth_imgs, real_imgs)
+        @debug case
+        @testset "$(case)" begin
+            expected = collect(_prepare_buffer(image))
+            filename = File{DataFormat{:PNG}}(joinpath(PNG_TEST_PATH, "test_img_$(case).png"))
+            @testset "write" begin
+                @test save(filename, image) == 0
+            end
+            @testset "read" begin
+                global read_in = load(filename)
+                @test read_in isa Matrix
+            end
+            @testset "compare" begin
+                @test all(expected .≈ read_in)
+            end
+        end
+    end
+
+    for (case, exception, image) in invalid_imgs
+        @debug case
+        @testset "$(case) throws" begin
+            @test_throws exception save(
+                File{DataFormat{:PNG}}(joinpath(PNG_TEST_PATH, "test_img_err_$(case).png")),
+                image
+            )
+        end
+    end
+
+    for (case, func_in, image) in edge_case_imgs
+        @debug case
+        @testset "$(case)" begin
+            filename = File{DataFormat{:PNG}}(joinpath(PNG_TEST_PATH, "test_img_$(case).png"))
+            @testset "write" begin
+                @test save(filename, image) == 0
+            end
+            @testset "read" begin
+                global read_in = load(filename)
+                @test read_in isa Matrix
+            end
+            @testset "compare" begin
+                @test all(read_in .== func_in(image))
+            end
+        end
+    end
+
+    if isdir(PNG_SUITE_PATH)
+        @testset "PngSuite" begin
+            for test_img_path in glob(joinpath("./**/$(PNG_SUITE_DIR)", "[!x]*[!_new].png"))
+                case = splitpath(test_img_path)[end]
+                @debug case
+                @testset "$(case)" begin
+                    global read_in = load(File{DataFormat{:PNG}}(test_img_path))
+                    @test read_in isa Matrix
+                    path, ext = splitext(test_img_path)
+                    @test save(File{DataFormat{:PNG}}(path * "_new" * ext), read_in) == 0
+                end
+            end
+
+
+            ## TODO: Malformed pngs that should error. This throws `signal (6): Aborted` since we
+            ## don't work with `png_jmpbuf` properly.
+            # for test_img_path in glob(joinpath("./**/$(PNG_SUITE_DIR)", "[x]*.png"))
+            #     case = splitpath(test_img_path)[end]
+            #     @debug case
+            #     @testset "$(case)" begin
+            #         @test_throws ErrorException load(test_img_path)
+            #     end
+            # end
+        end
+    end
+end
+
+
+# Cleanup
+isdir(PNG_TEST_PATH) && rm(PNG_TEST_PATH, recursive = true)


### PR DESCRIPTION
Port of https://github.com/ianshmean/ImageIO.jl/pull/3 where I also describe what is going on.

This _should_ work with https://github.com/JuliaIO/FileIO.jl/pull/257, at least locally it seems to work fine. I'd certainly welcome some code review here:)

I ran the benchmarks from https://github.com/JuliaIO/PNG.jl/issues/1, but I'm not sure how make FileIO actually use QuartzImageIO (guess it's only used on Mac?), so here are my local results:

```
[ Info: Testing with rand(RGB{N0f8}, 244, 244) image -----------------------------
[ Info: Testing FileIO with ImageMagick (dedicated environment, new instance)
Time to first save (including save): 2.2 seconds
Save @btime:  23.942 ms (1424 allocations: 597.88 KiB)
Load @btime:  4.331 ms (1584 allocations: 605.14 KiB)

[ Info: Testing FileIO with PNG (dedicated environment, new instance)
Time to first save (including save): 4.708 seconds
Save @btime:  2.700 ms (46 allocations: 178.64 KiB)
Load @btime:  3.009 ms (182 allocations: 359.53 KiB)
```
```
[ Info: Testing with rand(RGB{N0f8}, 20000, 4000) image -----------------------------
[ Info: Testing FileIO with ImageMagick (dedicated environment, new instance)
Time to first save (including save): 30.831 seconds
Save @btime:  27.494 s (1424 allocations: 686.72 MiB)
Load @btime:  5.206 s (1591 allocations: 686.73 MiB)

[ Info: Testing FileIO with PNG (dedicated environment, new instance)
Time to first save (including save): 6.485 seconds
Save @btime:  4.703 s (49 allocations: 229.04 MiB)
Load @btime:  4.599 s (185 allocations: 457.92 MiB)
```

Note that integrating this MR into FileIO might be technically breaking as the rules that determine the color_type and bit_depth might not always be the same as before (we'll need to verify that).